### PR TITLE
Roomモデルを作成する

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,2 @@
+class Room < ApplicationRecord
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 class Room < ApplicationRecord
-  validates :house_viewing_id, presence: true
   validates :name, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Room < ApplicationRecord
   validates :house_viewing_id, presence: true
   validates :name, presence: true

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,2 +1,4 @@
 class Room < ApplicationRecord
+  validates :house_viewing_id, presence: true
+  validates :name, presence: true
 end

--- a/db/migrate/20230622051911_create_rooms.rb
+++ b/db/migrate/20230622051911_create_rooms.rb
@@ -1,0 +1,10 @@
+class CreateRooms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rooms do |t|
+      t.references :house_viewing, null: false, foreign_key: true
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_025521) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_22_051911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,4 +21,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_025521) do
     t.index ["uuid"], name: "index_house_viewings_on_uuid", unique: true
   end
 
+  create_table "rooms", force: :cascade do |t|
+    t.bigint "house_viewing_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["house_viewing_id"], name: "index_rooms_on_house_viewing_id"
+  end
+
+  add_foreign_key "rooms", "house_viewings"
 end


### PR DESCRIPTION
## 概要 
Roomモデルを作成しました。またバリデーションを設定しました。

## スクリーンショット
* Roomsテーブル
<img width="700" alt="スクリーンショット 2023-06-22 15 05 21" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/8bc064a4-bb66-490e-a0d8-4a8fe85e70a6">

* レコードの作成
<img width="700" alt="スクリーンショット 2023-06-22 15 06 20" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/c4d5fa0b-ae1e-481c-811f-f07d7141ef19">

* レコードの作成（name, uuidがnilのとき）
<img width="700" alt="スクリーンショット 2023-06-22 15 06 46" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/b946b437-6541-4520-85ab-4a2a805059ea">

## 関連Issue
- #76 

## 備考
### house_viewing_idについて
当初はhouse_viewing_idにユニーク制約がついていましたが、同じhouse_viewing_idを持ったRoomデータを複数作成できなくなるため、ユニーク制約を取り外しています。以下のリンクでも同じ修正を行いました。
- #5 
- #76 

Roomsテーブルは以下の形を想定しています。
| カラム名 | データ型 | PK | FK | UQ | NN |
| --- | --- | --- | --- | --- | --- |
| id | integer | ○ |  | ○ | ○ | 
| house_viewing_id | integer |  | ○ |  | ○ | 
| name | string |  |  |  | ○ | 
| created_at | datetime |  |  |  | ○ | 
| updated_at | datetime |  |  |  | ○ | 

## コミットについて
実装で必要となったため、[HouseViewingモデルの作成](https://github.com/uchihiro04/house-viewing-score-log/commit/c2300b55208f7b1c473550be25b1ee56aa944dd8)から[マイグレーションの実行](https://github.com/uchihiro04/house-viewing-score-log/commit/d7ef52ede1cb187a6fa357c9b795ad3d225513d0)まではチェリーピックをしています。