### PR TITLE
スコア入力ページに「入力者一覧」を作成する

### DIFF
--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -6,13 +6,14 @@
 
   .flex
     h2 入力者一覧
-    = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
+    - if @score.persisted?
+      = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
   - @room.scores.each do |score|
     ul
       .flex
         li = score.reviewer_name
         = link_to '編集'
-        
+
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name
   - evaluation_items.each do |evaluation_item|

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -9,8 +9,10 @@
     = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
   - @room.scores.each do |score|
     ul
-      li = score.reviewer_name
-
+      .flex
+        li = score.reviewer_name
+        = link_to '編集'
+        
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name
   - evaluation_items.each do |evaluation_item|

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -4,7 +4,9 @@
 
   p 分かりやすい名前に変更しましょう。
 
-  h2 入力者一覧
+  .flex
+    h2 入力者一覧
+    = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
 
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -4,6 +4,8 @@
 
   p 分かりやすい名前に変更しましょう。
 
+  h2 入力者一覧
+
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name
   - evaluation_items.each do |evaluation_item|

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -9,7 +9,7 @@
     - if @score.persisted?
       = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
   - if @room.scores.blank?
-    p スコアを入力した人はいません    
+    p スコアを入力した人はいません
   - @room.scores.each do |score|
     ul
       .flex

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -7,6 +7,9 @@
   .flex
     h2 入力者一覧
     = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
+  - @room.scores.each do |score|
+    ul
+      li = score.reviewer_name
 
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -8,6 +8,8 @@
     h2 入力者一覧
     - if @score.persisted?
       = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
+  - if @room.scores.blank?
+    p スコアを入力した人はいません    
   - @room.scores.each do |score|
     ul
       .flex


### PR DESCRIPTION
## 概要 
スコア入力ページに「入力者一覧」を作成しました。
入力者一覧では以下の項目が表示されます。
* 新規入力ボタン（スコア編集ページの場合のみ）
* スコア入力者の名前
* スコアの編集ボタン

## スクリーンショット
* 入力者一覧
赤枠で囲った箇所が入力者一覧になります。
<img width="1440" alt="スクリーンショット 2023-06-29 13 04 07" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/542f7bc0-f45e-430a-8e01-6edc1d1c22cf">

* デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
赤枠で囲った箇所が入力者一覧になります。
<img width="200" alt="スクリーンショット 2023-06-29 13 05 56" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/94128248-5d6b-48b4-8c22-6cd8fa9e3e8c">

## 関連Issue
- #88 

## 備考
現段階ではスコア編集ページが存在しないため、以下の実装は別Issueで行います。
* 編集ボタンに遷移先を設定する

Close #88 