### PR TITLE
お部屋のスコア編集ページを作成する

### DIFF
--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -5,7 +5,6 @@ module HouseViewings
     class ScoresController < ApplicationController
       before_action :set_house_viewing, :set_room, only: %i[new create edit update]
       before_action :set_score, only: %i[edit update]
-      before_action :set_new_room_name, only: %i[create update]
 
       def new
         @score = Score.new
@@ -14,6 +13,7 @@ module HouseViewings
       def edit; end
 
       def create
+        set_new_room_name
         @score = @room.scores.new(score_params)
 
         if @room.save
@@ -24,6 +24,7 @@ module HouseViewings
       end
 
       def update
+        set_new_room_name
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
         else

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -3,16 +3,14 @@
 module HouseViewings
   module Rooms
     class ScoresController < ApplicationController
-      before_action :set_house_viewing, only: %i[new create edit update]
-      before_action :set_room, only: %i[new create edit update]
+      before_action :set_house_viewing, :set_room, only: %i[new create edit update]
+      before_action :set_score, only: %i[edit update]
 
       def new
         @score = Score.new
       end
 
-      def edit
-        @score = @room.scores.find(params[:id])
-      end
+      def edit; end
 
       def create
         room_name = params[:score][:room][:name]
@@ -29,7 +27,6 @@ module HouseViewings
       def update
         room_name = params[:score][:room][:name]
         @room.update!(name: room_name) if @room.name != room_name
-        @score = @room.scores.find(params[:id])
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: 'スコアを更新しました。'
         else
@@ -45,6 +42,10 @@ module HouseViewings
 
       def set_room
         @room = @house_viewing.rooms.find(params[:room_id])
+      end
+
+      def set_score
+        @score = @room.scores.find(params[:id])
       end
 
       def score_params

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -3,8 +3,8 @@
 module HouseViewings
   module Rooms
     class ScoresController < ApplicationController
-      before_action :set_house_viewing, only: %i[new create edit]
-      before_action :set_room, only: %i[new create edit]
+      before_action :set_house_viewing, only: %i[new create edit update]
+      before_action :set_room, only: %i[new create edit update]
 
       def new
         @score = Score.new
@@ -23,6 +23,17 @@ module HouseViewings
           redirect_to house_viewing_rooms_path, notice: 'スコアを登録しました。'
         else
           render :new, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        room_name = params[:score][:room][:name]
+        @room.update!(name: room_name) if @room.name != room_name
+        @score = @room.scores.find(params[:id])
+        if @score.update(score_params)
+          redirect_to house_viewing_rooms_path, notice: 'スコアを更新しました。'
+        else
+          render :edit, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -5,7 +5,7 @@ module HouseViewings
     class ScoresController < ApplicationController
       before_action :set_house_viewing, :set_room, only: %i[new create edit update]
       before_action :set_score, only: %i[edit update]
-      before_action :fetch_room_name, only: %i[create update]
+      before_action :set_new_room_name, only: %i[create update]
 
       def new
         @score = Score.new
@@ -15,7 +15,6 @@ module HouseViewings
 
       def create
         @score = @room.scores.new(score_params)
-        @room.name = @room_name if @room.name != @room_name
 
         if @room.save
           redirect_to house_viewing_rooms_path, notice: t('notice.create', model: @score.class.model_name.human)
@@ -25,8 +24,6 @@ module HouseViewings
       end
 
       def update
-        @room.name = @room_name if @room.name != @room_name
-
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
         else
@@ -44,8 +41,8 @@ module HouseViewings
         @room = @house_viewing.rooms.find(params[:room_id])
       end
 
-      def fetch_room_name
-        @room_name = params[:score][:room][:name]
+      def set_new_room_name
+        @room.name = params[:score][:room][:name]
       end
 
       def set_score

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -3,11 +3,15 @@
 module HouseViewings
   module Rooms
     class ScoresController < ApplicationController
-      before_action :set_house_viewing, only: %i[new create]
-      before_action :set_room, only: %i[new create]
+      before_action :set_house_viewing, only: %i[new create edit]
+      before_action :set_room, only: %i[new create edit]
 
       def new
         @score = Score.new
+      end
+
+      def edit
+        @score = @room.scores.find(params[:id])
       end
 
       def create

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -18,7 +18,7 @@ module HouseViewings
         @room.name = room_name if @room.name != room_name
 
         if @room.save
-          redirect_to house_viewing_rooms_path, notice: 'スコアを登録しました。'
+          redirect_to house_viewing_rooms_path, notice: t('notice.create', model: @score.class.model_name.human)
         else
           render :new, status: :unprocessable_entity
         end
@@ -29,7 +29,7 @@ module HouseViewings
         @room.name = room_name if @room.name != room_name
 
         if @score.update(score_params)
-          redirect_to house_viewing_rooms_path, notice: 'スコアを更新しました。'
+          redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
         else
           render :edit, status: :unprocessable_entity
         end

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -26,7 +26,8 @@ module HouseViewings
 
       def update
         room_name = params[:score][:room][:name]
-        @room.update!(name: room_name) if @room.name != room_name
+        @room.name = room_name if @room.name != room_name
+
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: 'スコアを更新しました。'
         else

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -17,7 +17,7 @@ module HouseViewings
         @score = @room.scores.new(score_params)
 
         if @room.save
-          redirect_to house_viewing_rooms_path, notice: t('notice.create', model: @score.class.model_name.human)
+          redirect_to house_viewing_rooms_path, notice: t('notice.create', model: @score.model_name.human)
         else
           render :new, status: :unprocessable_entity
         end
@@ -26,7 +26,7 @@ module HouseViewings
       def update
         set_room_name
         if @score.update(score_params)
-          redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
+          redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.model_name.human)
         else
           render :edit, status: :unprocessable_entity
         end

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -13,7 +13,7 @@ module HouseViewings
       def edit; end
 
       def create
-        set_new_room_name
+        set_room_name
         @score = @room.scores.new(score_params)
 
         if @room.save
@@ -24,7 +24,7 @@ module HouseViewings
       end
 
       def update
-        set_new_room_name
+        set_room_name
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
         else
@@ -42,7 +42,7 @@ module HouseViewings
         @room = @house_viewing.rooms.find(params[:room_id])
       end
 
-      def set_new_room_name
+      def set_room_name
         @room.name = params[:score][:room][:name]
       end
 

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -5,6 +5,7 @@ module HouseViewings
     class ScoresController < ApplicationController
       before_action :set_house_viewing, :set_room, only: %i[new create edit update]
       before_action :set_score, only: %i[edit update]
+      before_action :fetch_room_name, only: %i[create update]
 
       def new
         @score = Score.new
@@ -13,9 +14,8 @@ module HouseViewings
       def edit; end
 
       def create
-        room_name = params[:score][:room][:name]
         @score = @room.scores.new(score_params)
-        @room.name = room_name if @room.name != room_name
+        @room.name = @room_name if @room.name != @room_name
 
         if @room.save
           redirect_to house_viewing_rooms_path, notice: t('notice.create', model: @score.class.model_name.human)
@@ -25,8 +25,7 @@ module HouseViewings
       end
 
       def update
-        room_name = params[:score][:room][:name]
-        @room.name = room_name if @room.name != room_name
+        @room.name = @room_name if @room.name != @room_name
 
         if @score.update(score_params)
           redirect_to house_viewing_rooms_path, notice: t('notice.update', model: @score.class.model_name.human)
@@ -43,6 +42,10 @@ module HouseViewings
 
       def set_room
         @room = @house_viewing.rooms.find(params[:room_id])
+      end
+
+      def fetch_room_name
+        @room_name = params[:score][:room][:name]
       end
 
       def set_score

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Score < ApplicationRecord
-  belongs_to :room
+  belongs_to :room, autosave: true
 
   with_options presence: true do
     validates :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -11,16 +11,16 @@
 
   .flex
     h2 入力者一覧
-    - if @score.persisted?
-      = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
-  - if @room.scores.blank?
+    - if score.persisted?
+      = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
+  - if room.scores.blank?
     p スコアを入力した人はいません
   ul
-    - @room.scores.each do |score|
+    - room.scores.each do |score|
       - if score.persisted?
         .flex
           li = score.reviewer_name
-          = link_to '編集', edit_house_viewing_room_score_path(@house_viewing, @room, score)
+          = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score)
 
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -20,7 +20,8 @@
     ul
       .flex
         li = score.reviewer_name
-        = link_to '編集', edit_house_viewing_room_score_path(@house_viewing, @room, score)
+        - if score.persisted?
+          = link_to '編集', edit_house_viewing_room_score_path(@house_viewing, @room, score)
 
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -1,8 +1,7 @@
-- [room, score].each do |object|
-  - if object.errors.present?
-    ul
-      - object.errors.full_messages.each do |message|
-       li = message
+- if score.errors.present?
+  ul
+    - score.errors.full_messages.each do |message|
+      li = message
 
 = form_with model: [house_viewing, room, score], local: true do |form|
   = form.fields_for :room do |room_fields|

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -20,7 +20,7 @@
     ul
       .flex
         li = score.reviewer_name
-        = link_to '編集'
+        = link_to '編集', edit_house_viewing_room_score_path(@house_viewing, @room, score)
 
   h2 入力者（名前・ニックネーム）
   = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -16,11 +16,11 @@
       = link_to '新規入力', new_house_viewing_room_score_path(room_id: @room.id)
   - if @room.scores.blank?
     p スコアを入力した人はいません
-  - @room.scores.each do |score|
-    ul
-      .flex
-        li = score.reviewer_name
-        - if score.persisted?
+  ul
+    - @room.scores.each do |score|
+      - if score.persisted?
+        .flex
+          li = score.reviewer_name
           = link_to '編集', edit_house_viewing_room_score_path(@house_viewing, @room, score)
 
   h2 入力者（名前・ニックネーム）

--- a/app/views/house_viewings/rooms/scores/edit.html.slim
+++ b/app/views/house_viewings/rooms/scores/edit.html.slim
@@ -1,5 +1,4 @@
 .flex
   = link_to '<', house_viewing_rooms_path
-  h1
-    = "スコアを編集する"
+  h1 スコアを編集する
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/edit.html.slim
+++ b/app/views/house_viewings/rooms/scores/edit.html.slim
@@ -1,5 +1,5 @@
 .flex
   = link_to '<', house_viewing_rooms_path
   h1
-    = "#{@room.name}を編集する"
-= render partial: 'form'
+    = "スコアを編集する"
+= render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/edit.html.slim
+++ b/app/views/house_viewings/rooms/scores/edit.html.slim
@@ -1,0 +1,5 @@
+.flex
+  = link_to '<', house_viewing_rooms_path
+  h1
+    = "#{@room.name}を編集する"
+= render partial: 'form'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -198,3 +198,7 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  notice:
+    create: "%{model}を作成しました。"
+    update: "%{model}を編集しました。"
+    destroy: "%{model}を削除しました。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :house_viewings, param: :uuid do 
     resources :rooms, only: [:index], module: :house_viewings do
-      resources :scores, only: [:new, :create], module: :rooms
+      resources :scores, only: [:new, :create, :edit, :update], module: :rooms
     end
   end
 end


### PR DESCRIPTION
## 概要 
お部屋のスコア編集ページを作成しました。
あわせて、スコア入力・編集ページの「入力者一覧」について、入力者ごとに「編集」ボタンのリンクを設定しました。

## スクリーンショット
* お部屋のスコア編集ページ
<img width="700" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/ebbd41ee-b295-4665-9813-62aee5e0f1ca">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/e562123a-de76-4972-b3a6-c9c42071761b">


* 作成後の画面
お部屋の内見一覧ページにリダイレクトし、「スコアを登録しました」と表示されます（赤枠の部分）。
<img width="700" alt="スクリーンショット 2023-06-30 9 55 56" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/b4f6eecc-590e-403e-866c-36b3915bc80d">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合（赤枠の部分）。
<img width="200" alt="スクリーンショット 2023-06-30 9 58 46" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/1e320716-180f-40d0-91db-e029b0e5bdf0">

## 関連Issue
- #82 

## 備考
以下の実装は別Issueで行います。
* デザイン

Close #82 
