### PR TITLE
「スコアを見る」ボタンを作成する

### DIFF
--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -5,5 +5,8 @@ table
       tr
         td
           = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
+          
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
+= link_to 'スコアを見る',  house_viewing_scores_path
+
 p URLを共有すると、複数人で採点ができます。

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -5,8 +5,8 @@ table
       tr
         td
           = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
-          
+
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
-= link_to 'スコアを見る',  house_viewing_scores_path
+= link_to 'スコアを見る', house_viewing_scores_path
 
 p URLを共有すると、複数人で採点ができます。


### PR DESCRIPTION
## 概要 
お部屋の内見一覧ページに「スコアを見る」ボタンを作成しました。
「スコアを見る」をクリック・タップすると、スコア結果ページへ遷移します。

## スクリーンショット
* 「スコアを見る」をクリックし、スコア結果ページへ遷移する様子

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/dd1123f9-8d66-4150-b85a-d7a566e80bbf


デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/49f0f188-5f78-435d-a91d-f5c1df6b7228

## 関連Issue
- #89 

Close #89 
