### PR TITLE
お部屋のスコア詳細ページを作成する

### DIFF
--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -3,8 +3,10 @@
 module HouseViewings
   module Rooms
     class ScoresController < ApplicationController
-      before_action :set_house_viewing, :set_room, only: %i[new create edit update]
+      before_action :set_house_viewing, :set_room, only: %i[index new create edit update]
       before_action :set_score, only: %i[edit update]
+
+      def index; end
 
       def new
         @score = Score.new

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -3,7 +3,7 @@
 module HouseViewings
   module Rooms
     class ScoresController < ApplicationController
-      before_action :set_house_viewing, :set_room, only: %i[index new create edit update]
+      before_action :set_house_viewing, :set_room
       before_action :set_score, only: %i[edit update]
 
       def index; end

--- a/app/views/house_viewings/rooms/scores/index.html.slim
+++ b/app/views/house_viewings/rooms/scores/index.html.slim
@@ -1,3 +1,7 @@
 .flex
   = link_to '<', house_viewing_scores_path
   h1 お部屋のスコア
+
+.flex
+  p = @room.name
+  p = "合計: #{@room.average_total_score} 点"

--- a/app/views/house_viewings/rooms/scores/index.html.slim
+++ b/app/views/house_viewings/rooms/scores/index.html.slim
@@ -1,0 +1,3 @@
+.flex
+  = link_to '<', house_viewing_scores_path
+  h1 お部屋のスコア

--- a/app/views/house_viewings/rooms/scores/index.html.slim
+++ b/app/views/house_viewings/rooms/scores/index.html.slim
@@ -5,3 +5,11 @@
 .flex
   p = @room.name
   p = "合計: #{@room.average_total_score} 点"
+
+h2 評価項目ごとの平均スコア
+table
+  tbody
+    - Room::EVALUATION_ITEMS.each do |evaluation_item|
+      tr
+        td = t("activerecord.attributes.score.#{evaluation_item}")
+        td = "#{@room.average_score(evaluation_item)} 点"

--- a/app/views/house_viewings/rooms/scores/index.html.slim
+++ b/app/views/house_viewings/rooms/scores/index.html.slim
@@ -11,5 +11,5 @@ table
   tbody
     - Room::EVALUATION_ITEMS.each do |evaluation_item|
       tr
-        td = t("activerecord.attributes.score.#{evaluation_item}")
+        td = Score.human_attribute_name(evaluation_item)
         td = "#{@room.average_score(evaluation_item)} 点"

--- a/app/views/house_viewings/rooms/scores/index.html.slim
+++ b/app/views/house_viewings/rooms/scores/index.html.slim
@@ -9,7 +9,7 @@
 h2 評価項目ごとの平均スコア
 table
   tbody
-    - Room::EVALUATION_ITEMS.each do |evaluation_item|
+    - Score::EVALUATION_ITEMS.each do |evaluation_item|
       tr
         td = Score.human_attribute_name(evaluation_item)
         td = "#{@room.average_score(evaluation_item)} 点"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :house_viewings, param: :uuid do 
     resources :scores, only: [:index], module: :house_viewings
     resources :rooms, only: [:index], module: :house_viewings do
-      resources :scores, only: [:new, :create, :edit, :update], module: :rooms
+      resources :scores, only: [:index, :new, :create, :edit, :update], module: :rooms
     end
   end
 end


### PR DESCRIPTION
## 概要 
お部屋のスコア詳細ページを作成しました。
スコア詳細ページでは、以下の項目をそれぞれ表示しています。
* 合計スコアの平均値
* 評価項目ごとのスコア（評価項目ごとのスコアの平均値を表示）

## スクリーンショット
* お部屋のスコア詳細ページ
<img width="700" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/2af8cacf-ec39-4a51-8def-450a08e2a5f8">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/3c959bcc-5c07-4b1a-a812-f2170419d523">

## 関連Issue
- #17 

## 備考
### 実装について
以下の実装は別Issueで行います。
* デザイン

### スコアの合計点数と各評価項目を足した点数について
「スコアの合計点数」と「各評価項目を足した点数」が一致しない理由は、合計点数と各評価項目をそれぞれ小数点第一位で四捨五入して整数にしているためです。
各評価項目を小数点第二位で四捨五入した場合、各評価項目を足した点数は20.0点となり、スコアの合計点数と一致する形となります。

Close #17 
