### PR TITLE
アプリ説明ページを作成

### DIFF
--- a/app/controllers/description/house_viewings_controller.rb
+++ b/app/controllers/description/house_viewings_controller.rb
@@ -2,6 +2,8 @@
 
 module Description
   class HouseViewingsController < ApplicationController
-    def show; end
+    def show
+      @house_viewing = HouseViewing.find_by!(uuid: params[:uuid])
+    end
   end
 end

--- a/app/controllers/description/house_viewings_controller.rb
+++ b/app/controllers/description/house_viewings_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Description
+  class HouseViewingsController < ApplicationController
+    def show; end
+  end
+end

--- a/app/views/description/house_viewings/show.html.slim
+++ b/app/views/description/house_viewings/show.html.slim
@@ -1,0 +1,1 @@
+= render partial: 'shared/summary'

--- a/app/views/description/house_viewings/show.html.slim
+++ b/app/views/description/house_viewings/show.html.slim
@@ -1,1 +1,2 @@
 = render partial: 'shared/summary'
+= link_to "#{Score.model_name.human}を入力する", house_viewing_rooms_path(@house_viewing)

--- a/app/views/description/house_viewings/show.html.slim
+++ b/app/views/description/house_viewings/show.html.slim
@@ -1,2 +1,2 @@
 = render partial: 'shared/summary'
-= link_to "#{Score.model_name.human}を入力する", house_viewing_rooms_path(@house_viewing)
+= link_to 'スコアを入力する', house_viewing_rooms_path(@house_viewing)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
       resources :scores, only: [:index, :new, :create, :edit, :update], module: :rooms
     end
   end
+
+  namespace :description do
+    resources :house_viewings, only: [:show], param: :uuid 
+  end
 end


### PR DESCRIPTION
## 概要 
招待URLからアクセスすると見ることのできるアプリ説明ページを作成しました。
「スコアを入力する」ボタンを押すと、uuidに応じた内見一覧ページに遷移します。

## スクリーンショット
* TOPページ

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/22689410-ab51-41b3-be0c-7a30e978529b

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/c0b9366b-bbc0-49f2-b134-ed769b8a6179

## 関連Issue
- #91 

## 備考
### 実装について
以下の実装は別Issueで行います。
* デザイン

Close #91 
