### PR TITLE
「招待URLをコピー」ボタンを作成する

### DIFF
--- a/app/controllers/house_viewings/rooms_controller.rb
+++ b/app/controllers/house_viewings/rooms_controller.rb
@@ -3,8 +3,8 @@
 module HouseViewings
   class RoomsController < ApplicationController
     def index
-      house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
-      @rooms = house_viewing.rooms.order(:created_at)
+      @house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
+      @rooms = @house_viewing.rooms.order(:created_at)
     end
   end
 end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module HouseViewings
-  module RoomsHelper
-    def description_page_url(house_viewing)
-      "#{request.base_url}/description/house_viewings/#{house_viewing.uuid}"
-    end
-  end
-end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module HouseViewings
+  module RoomsHelper
+    def description_page_url(house_viewing)
+      "#{request.base_url}/description/house_viewings/#{house_viewing.uuid}"
+    end
+  end
+end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [ "url" ]
   
-  copyDescriptionPageUrl() {
+  copySharedUrl() {
     navigator.clipboard.writeText(this.urlTarget.value)
   }
 }

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "source" ]
+  
+  copyDescriptionPageUrl() {
+    navigator.clipboard.writeText(this.sourceTarget.value)
+  }
+}

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,9 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "source" ]
+  static targets = [ "url" ]
   
   copyDescriptionPageUrl() {
-    navigator.clipboard.writeText(this.sourceTarget.value)
+    navigator.clipboard.writeText(this.urlTarget.value)
   }
 }

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -11,5 +11,5 @@ p 1件以上スコアの入力が完了していると、スコアを見るこ�
 
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]
-  input[data-clipboard-target="source" type="hidden" value="#{description_page_url(@house_viewing)}"]
+  input[data-clipboard-target="url" type="hidden" value="#{description_page_url(@house_viewing)}"]
   button[data-action="clipboard#copyDescriptionPageUrl"] 招待URLをコピー

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -11,5 +11,5 @@ p 1件以上スコアの入力が完了していると、スコアを見るこ�
 
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]
-  input[data-clipboard-target="url" type="hidden" value="#{description_page_url(@house_viewing)}"]
+  input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
   button[data-action="clipboard#copyDescriptionPageUrl"] 招待URLをコピー

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -10,3 +10,6 @@ p 1件以上スコアの入力が完了していると、スコアを見るこ�
 = link_to 'スコアを見る', house_viewing_scores_path
 
 p URLを共有すると、複数人で採点ができます。
+.flex[data-controller="clipboard"]
+  input[data-clipboard-target="source" type="hidden" value="#{request.base_url}/description/house_viewings/#{@house_viewing.uuid}"]
+  button[data-action="clipboard#copyDescriptionPageUrl"] 招待URLをコピー

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -11,5 +11,5 @@ p 1件以上スコアの入力が完了していると、スコアを見るこ�
 
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]
-  input[data-clipboard-target="source" type="hidden" value="#{request.base_url}/description/house_viewings/#{@house_viewing.uuid}"]
+  input[data-clipboard-target="source" type="hidden" value="#{description_page_url(@house_viewing)}"]
   button[data-action="clipboard#copyDescriptionPageUrl"] 招待URLをコピー

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -12,4 +12,4 @@ p 1件以上スコアの入力が完了していると、スコアを見るこ�
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]
   input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
-  button[data-action="clipboard#copyDescriptionPageUrl"] 招待URLをコピー
+  button[data-action="clipboard#copySharedUrl"] 招待URLをコピー


### PR DESCRIPTION
## 概要 
内見一覧ページに、「招待URLをコピー」ボタンを作成しました。
ボタンを押すと、HouseViewingレコードのuuidにもとづいたアプリ説明ページのURLがクリップボードにコピーされます。

## スクリーンショット
* 「招待URLをコピー」ボタン（赤枠にて強調）
<img width="700" alt="230706_招待URLをコピーボタン" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/fe0d2102-0615-4efc-b8d1-41ef15b8e83a">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230706_招待URLをコピーボタン（スマートフォン）" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/0f94f50b-67b5-4d5f-bdbe-5717ad40bcd0">

* コピーしたURLでアプリ説明ページに遷移する様子

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/64b65159-30f5-4227-9127-84286b5ca64a


## 関連Issue
- #90 

## 参考リンク
[Stimulus Handbook](https://stimulus.hotwired.dev/handbook/building-something-real)

## 備考
### 実装について
以下の実装は別Issueで行います。
* デザイン

Close #90 
