### PR TITLE
全部屋のスコアが未入力の場合、お部屋のスコア結果ページに遷移できないようにする

### DIFF
--- a/app/controllers/house_viewings/scores_controller.rb
+++ b/app/controllers/house_viewings/scores_controller.rb
@@ -8,6 +8,8 @@ module HouseViewings
       house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
       @rooms = house_viewing.rooms.includes(:scores).order(:created_at)
 
+      redirect_to house_viewing_rooms_path if @rooms.all? { |room| room.scores.blank? }
+
       @top_two_rooms = @rooms.max_by(TOP_TWO, &:average_total_score)
     end
   end

--- a/app/controllers/house_viewings/scores_controller.rb
+++ b/app/controllers/house_viewings/scores_controller.rb
@@ -8,9 +8,15 @@ module HouseViewings
       house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
       @rooms = house_viewing.rooms.includes(:scores).order(:created_at)
 
-      redirect_to house_viewing_rooms_path if @rooms.all? { |room| room.scores.blank? }
+      redirect_to house_viewing_rooms_path, alert: t('alert.no_scores') if rooms_score_blank?
 
       @top_two_rooms = @rooms.max_by(TOP_TWO, &:average_total_score)
+    end
+
+    private
+
+    def rooms_score_blank?
+      @rooms.all? { |room| room.scores.blank? }
     end
   end
 end

--- a/app/controllers/house_viewings/scores_controller.rb
+++ b/app/controllers/house_viewings/scores_controller.rb
@@ -8,15 +8,9 @@ module HouseViewings
       house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
       @rooms = house_viewing.rooms.includes(:scores).order(:created_at)
 
-      redirect_to house_viewing_rooms_path, alert: t('alert.no_scores') if rooms_score_blank?
+      redirect_to house_viewing_rooms_path, alert: t('alert.no_scores') unless Room.score_entered?(@rooms.ids)
 
       @top_two_rooms = @rooms.max_by(TOP_TWO, &:average_total_score)
-    end
-
-    private
-
-    def rooms_score_blank?
-      @rooms.all? { |room| room.scores.blank? }
     end
   end
 end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -3,7 +3,7 @@
 module HouseViewings
   module RoomsHelper
     def scores?(rooms)
-      Score.where(room_id: rooms.ids).exists?
+      Score.exists?(room_id: rooms.ids)
     end
   end
 end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module HouseViewings
-  module RoomsHelper
-    def scores?(rooms)
-      Score.exists?(room_id: rooms.ids)
-    end
-  end
-end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module HouseViewings
+  module RoomsHelper
+    def scores?(rooms)
+      rooms.any? { |room| room.scores.exists? }
+    end
+  end
+end

--- a/app/helpers/house_viewings/rooms_helper.rb
+++ b/app/helpers/house_viewings/rooms_helper.rb
@@ -3,7 +3,7 @@
 module HouseViewings
   module RoomsHelper
     def scores?(rooms)
-      rooms.any? { |room| room.scores.exists? }
+      Score.where(room_id: rooms.ids).exists?
     end
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -6,6 +6,10 @@ class Room < ApplicationRecord
 
   validates :name, presence: true
 
+  def self.score_entered?(room_ids)
+    Score.exists?(room_id: room_ids)
+  end
+
   def average_total_score
     sum_total_scores = Score::EVALUATION_ITEMS.sum { |attribute_name| scores.sum(attribute_name) }.to_f
     return 0 if scores.blank?

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -7,7 +7,7 @@ table
           = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
 
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
-= link_to 'スコアを見る', house_viewing_scores_path
+= link_to_if scores?(@rooms), 'スコアを見る', house_viewing_scores_path
 
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -7,7 +7,7 @@ table
           = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
 
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
-= link_to_if scores?(@rooms), 'スコアを見る', house_viewing_scores_path
+= link_to_if Room.score_entered?(@rooms.ids), 'スコアを見る', house_viewing_scores_path
 
 p URLを共有すると、複数人で採点ができます。
 .flex[data-controller="clipboard"]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,5 +11,5 @@ html
     = javascript_importmap_tags
   body
     main.container.mx-auto.mt-28.px-5
-      = flash.notice.presence
+      = flash.notice.presence || flash.alert.presence
       = yield

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -202,3 +202,5 @@ ja:
     create: "%{model}を作成しました。"
     update: "%{model}を編集しました。"
     destroy: "%{model}を削除しました。"
+  alert:
+    no_scores: スコアが未入力です


### PR DESCRIPTION
## 概要 
全部屋のスコアが未入力の場合、以下のような形になるように変更しました。
* 「スコアを見る」をタップ・クリックしてもスコア結果ページに遷移しない。
* お部屋のスコア結果ページに直接アクセスすると内見一覧ページにリダイレクトする。
* リダイレクト時は「スコアが未入力です」というフラッシュメッセージが表示される。

## スクリーンショット
* 全部屋のスコアが未入力の状態で、「スコアを見る」ボタンのクリックを試みた場合（リンクのない状態）

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/e92eeb74-95af-4bc8-a66c-8c32d2872691

* 全部屋のスコアが未入力の状態で、お部屋のスコア結果ページに直接アクセスした場合

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/8bbd6fa0-3ce5-4498-85ab-8d85c85c37b1

## 関連Issue
- close #80 

Close #80 
