### PR TITLE
スコア結果ページの表示形式を変更する

### DIFF
--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -7,7 +7,7 @@ module HouseViewings
       before_action :set_score, only: %i[edit update]
 
       def index
-        redirect_to house_viewing_scores_path, alert: t('alert.no_scores') if @room.scores_blank?
+        redirect_to house_viewing_scores_path, alert: t('alert.no_scores') unless Room.score_entered?(@room.id)
       end
 
       def new

--- a/app/controllers/house_viewings/rooms/scores_controller.rb
+++ b/app/controllers/house_viewings/rooms/scores_controller.rb
@@ -6,7 +6,9 @@ module HouseViewings
       before_action :set_house_viewing, :set_room
       before_action :set_score, only: %i[edit update]
 
-      def index; end
+      def index
+        redirect_to house_viewing_scores_path, alert: t('alert.no_scores') if @room.scores_blank?
+      end
 
       def new
         @score = Score.new

--- a/app/controllers/house_viewings/scores_controller.rb
+++ b/app/controllers/house_viewings/scores_controller.rb
@@ -6,7 +6,7 @@ module HouseViewings
 
     def index
       house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
-      @rooms = house_viewing.rooms.includes(:scores).order(:created_at)
+      @rooms = house_viewing.rooms.includes(:scores).joins(:scores).order(:created_at)
 
       redirect_to house_viewing_rooms_path, alert: t('alert.no_scores') unless Room.score_entered?(@rooms.ids)
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -22,6 +22,4 @@ class Room < ApplicationRecord
 
     (scores.sum(attribute_name).to_f / scores.length).round(1)
   end
-
-  delegate :blank?, to: :scores, prefix: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -20,7 +20,7 @@ class Room < ApplicationRecord
   def average_score(attribute_name)
     return 0 if scores.blank?
 
-    (scores.sum(attribute_name).to_f / scores.length).round
+    (scores.sum(attribute_name).to_f / scores.length).round(1)
   end
 
   delegate :blank?, to: :scores, prefix: true

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -22,4 +22,6 @@ class Room < ApplicationRecord
 
     (scores.sum(attribute_name).to_f / scores.length).round
   end
+
+  delegate :blank?, to: :scores, prefix: true
 end

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -33,5 +33,5 @@ table
   tbody
     - @rooms.each do |room|
       tr
-        td = link_to room.name
+        td = link_to room.name, house_viewing_room_scores_path(room_id: room.id)
         td = "#{room.average_total_score} 点"


### PR DESCRIPTION
## 概要 
スコア結果ページについて、以下のような形式に変更しました。
* スコアが入力されていない部屋は非表示
* 各部屋について、スコア詳細ページへのリンクを設定
* 評価項目の平均点を小数点第一位まで表示

また、 スコアが未入力の状態でスコア詳細ページに遷移した時、お部屋結果ページにリダイレクトされる形に設定しました。

## スクリーンショット
* お部屋のスコア結果ページ
<img width="1440" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/e2c81f2a-e313-4153-bd52-877235468f97">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="340" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/5d46299a-0130-4e3b-93d7-06c86b264a14">

* スコアが未入力の状態でスコア詳細ページに遷移した場合

https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/09669087-3f53-4a3d-ae85-17084706cba4

## 関連Issue
- #86 

Close #86 
