### PR TITLE
お部屋の内見一覧ページにスコア入力数を表示する

### DIFF
--- a/app/controllers/house_viewings/rooms_controller.rb
+++ b/app/controllers/house_viewings/rooms_controller.rb
@@ -4,7 +4,7 @@ module HouseViewings
   class RoomsController < ApplicationController
     def index
       @house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
-      @rooms = @house_viewing.rooms.order(:created_at)
+      @rooms = @house_viewing.rooms.includes([:scores]).order(:created_at)
     end
   end
 end

--- a/app/controllers/house_viewings/rooms_controller.rb
+++ b/app/controllers/house_viewings/rooms_controller.rb
@@ -4,7 +4,7 @@ module HouseViewings
   class RoomsController < ApplicationController
     def index
       @house_viewing = HouseViewing.find_by!(uuid: params[:house_viewing_uuid])
-      @rooms = @house_viewing.rooms.includes([:scores]).order(:created_at)
+      @rooms = @house_viewing.rooms.includes(:scores).order(:created_at)
     end
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -22,8 +22,4 @@ class Room < ApplicationRecord
 
     (scores.sum(attribute_name).to_f / scores.length).round(1)
   end
-
-  def number_of_scores
-    scores.length
-  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -22,4 +22,8 @@ class Room < ApplicationRecord
 
     (scores.sum(attribute_name).to_f / scores.length).round(1)
   end
+
+  def number_of_scores
+    scores.length
+  end
 end

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -4,7 +4,7 @@ table
     - @rooms.each do |room|
       tr
         td = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
-        td = "スコア入力数: #{room.number_of_scores}"
+        td = "スコア入力数: #{room.scores.length}"
 
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
 = link_to_if Room.score_entered?(@rooms.ids), 'スコアを見る', house_viewing_scores_path

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -3,8 +3,8 @@ table
   tbody
     - @rooms.each do |room|
       tr
-        td
-          = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
+        td = link_to room.name, new_house_viewing_room_score_path(room_id: room.id)
+        td = "スコア入力数: #{room.number_of_scores}"
 
 p 1件以上スコアの入力が完了していると、スコアを見ることができます。
 = link_to_if Room.score_entered?(@rooms.ids), 'スコアを見る', house_viewing_scores_path


### PR DESCRIPTION
## 概要 
お部屋の内見一覧ページに、部屋ごとのスコア入力数を表示しました。

## スクリーンショット
* スコア入力数の表示（赤枠で強調）
<img width="700" alt="230711_スコア入力数" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/e55b5b82-eb88-4d58-8f43-572a9bd5d9c2">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230711_スコア入力数（スマートフォン）" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/a64639b3-96ef-47ae-8d7c-22e7c51c1dce">

## 関連Issue
- #79 

Close #79 
