### PR TITLE
お部屋のスコア入力ページをデザインする

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,6 +7,10 @@
     @apply bg-slate-950 cursor-pointer hover:bg-slate-700 mb-5 py-2 px-4 rounded text-center text-white w-full;
   }
 
+  .btn-sm {
+    @apply bg-slate-950 block hover:bg-slate-700 py-0.5 px-1 rounded-lg text-center text-sm text-white w-16;
+  }
+
   .flash-message {
     @apply border px-4 py-3 rounded;
   }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -26,4 +26,8 @@
   .back-button {
     @apply absolute left-10 md:left-3;
   }
+
+  .text-field {
+    @apply block w-full rounded-lg;
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,7 +8,7 @@
   }
 
   .flash-message {
-    @apply border px-4 py-3;
+    @apply border px-4 py-3 rounded;
   }
 
   .header {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -26,6 +26,10 @@
   .h1-title {
     @apply font-bold text-2xl;
   }
+  
+  .h2-title {
+    @apply font-bold text-base;
+  }
 
   .back-button {
     @apply absolute left-10 md:left-3;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,7 +16,7 @@
   }
 
   .header-container {
-    @apply container flex justify-center mx-auto p-5;
+    @apply container flex items-center justify-center mx-auto p-5;
   }
 
   .h1-title {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,10 +16,14 @@
   }
 
   .header-container {
-    @apply container flex items-center justify-center mx-auto p-5;
+    @apply container flex items-center justify-center mx-auto p-5 relative md:w-1/3;
   }
 
   .h1-title {
     @apply font-bold text-2xl;
+  }
+
+  .back-button {
+    @apply absolute left-10 md:left-3;
   }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,7 +4,7 @@
 
 @layer components {
   .btn-lg {
-    @apply bg-slate-950 hover:bg-slate-700 mb-5 py-2 px-4 rounded text-center text-white w-full md:w-1/3 mx-auto;
+    @apply bg-slate-950 cursor-pointer hover:bg-slate-700 mb-5 py-2 px-4 rounded text-center text-white w-full;
   }
 
   .flash-message {

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -18,4 +18,6 @@ class Score < ApplicationRecord
   end
 
   EVALUATION_ITEMS = %i[living_room storage kitchen bath toilet equipment surroundings rent].freeze
+  HIGHEST_SCORE = 5
+  LOWEST_SCORE = 1
 end

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -29,4 +29,3 @@ header.header
     .flex[data-controller="clipboard"]
       input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
       button.btn-lg[data-action="clipboard#copySharedUrl"] 招待URLをコピー
-

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -18,13 +18,13 @@ header.header
                 path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"
                 d="m1 13 5.7-5.326a.909.909 0 0 0 0-1.348L1 1"]
 
-  p.md:w-1/3.mx-auto 1件以上スコアの入力が完了していると、スコアを見ることができます。
-  - if Room.score_entered?(@rooms.ids)
-    = link_to 'スコアを見る', house_viewing_scores_path, class: 'block btn-lg'
-  - else
-    span.bg-gray-400.block.btn-lg.pointer-events-none スコアを見る
+    p 1件以上スコアの入力が完了していると、スコアを見ることができます。
+    - if Room.score_entered?(@rooms.ids)
+      = link_to 'スコアを見る', house_viewing_scores_path, class: 'block btn-lg'
+    - else
+      span.bg-gray-400.block.btn-lg.pointer-events-none スコアを見る
 
-  p.md:w-1/3.mx-auto URLを共有すると、複数人で採点ができます。
-  .flex[data-controller="clipboard"]
-    input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
-    button.btn-lg[data-action="clipboard#copySharedUrl"] 招待URLをコピー
+    p URLを共有すると、複数人で採点ができます。
+    .flex[data-controller="clipboard"]
+      input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
+      button.btn-lg[data-action="clipboard#copySharedUrl"] 招待URLをコピー

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -3,20 +3,21 @@ header.header
     h1.h1-title 内見したお部屋一覧
 
 .mx-10.my-6
-  ul.mb-2.md:w-1/3.mx-auto
-    - @rooms.each do |room|
-      li.border.border-b-0.border-black.cursor-pointer.px-2.py-1.last:border-b
-        = link_to new_house_viewing_room_score_path(room_id: room.id) do
-          .flex.justify-between.items-center
-            div
+  .md:w-1/3.mx-auto
+    ul.mb-2
+      - @rooms.each do |room|
+        li.border.border-b-0.border-black.cursor-pointer.px-2.py-1.last:border-b
+          = link_to new_house_viewing_room_score_path(room_id: room.id) do
+            .flex.justify-between.items-center
               div
-                = room.name
+                div
+                  = room.name
+                div
+                  = "スコア入力数: #{room.scores.length}"
               div
-                = "スコア入力数: #{room.scores.length}"
-            div
-              svg.w-4.h-4.mx-auto xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
-                path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"
-                d="m1 13 5.7-5.326a.909.909 0 0 0 0-1.348L1 1"]
+                svg.w-4.h-4.mx-auto xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+                  path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"
+                  d="m1 13 5.7-5.326a.909.909 0 0 0 0-1.348L1 1"]
 
     p 1件以上スコアの入力が完了していると、スコアを見ることができます。
     - if Room.score_entered?(@rooms.ids)
@@ -28,3 +29,4 @@ header.header
     .flex[data-controller="clipboard"]
       input[data-clipboard-target="url" type="hidden" value=description_house_viewing_url(@house_viewing)]
       button.btn-lg[data-action="clipboard#copySharedUrl"] 招待URLをコピー
+

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -13,7 +13,7 @@
 
       .mt-6
         .flex.items-center.justify-between
-          h2.font-bold.text-base 入力者一覧
+          h2.h2-title 入力者一覧
           - if score.persisted?
             = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
         - if room.scores.blank?
@@ -27,13 +27,13 @@
                 class: 'btn-sm'
 
       .mt-6
-        h2.font-bold.text-base 入力者（名前・ニックネーム）
+        h2.h2-title 入力者（名前・ニックネーム）
         = form.text_field :reviewer_name, class: 'text-field'
 
       .mt-6
         - evaluation_items.each do |evaluation_item|
           .mb-6
-            h2.font-bold.text-base
+            h2.h2-title
               = evaluation_item
             .flex.justify-between.mx-auto.text-sm.w-4/5
               p = good_evaluation_name(evaluation_item)

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -24,7 +24,7 @@
               .flex.items-center.justify-between.mt-2
                 li.w-3/4 = score.reviewer_name
                 = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score),
-                class: 'bg-slate-950 block hover:bg-slate-700 py-0.5 px-1 rounded-lg text-center text-sm text-white w-16'
+                class: 'btn-sm'
 
       .mt-6
         h2.font-bold.text-base 入力者（名前・ニックネーム）

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -13,7 +13,7 @@
 
       .mt-4
         .flex.items-center.justify-between
-          h2.font-bold.text-lg 入力者一覧
+          h2.font-bold.text-base 入力者一覧
           - if score.persisted?
             = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
         - if room.scores.blank?
@@ -26,8 +26,10 @@
                 = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score),
                 class: 'bg-slate-950 block hover:bg-slate-700 py-0.5 px-1 rounded-lg text-center text-sm text-white w-16'
 
-      h2 入力者（名前・ニックネーム）
-      = form.text_field :reviewer_name
+      .mt-4
+        h2.font-bold.text-base 入力者（名前・ニックネーム）
+        = form.text_field :reviewer_name, class: 'block w-full'
+
       - evaluation_items.each do |evaluation_item|
         h2
           = evaluation_item

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -11,18 +11,20 @@
 
       p 分かりやすい名前に変更しましょう。
 
-      .flex
-        h2 入力者一覧
-        - if score.persisted?
-          = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
-      - if room.scores.blank?
-        p スコアを入力した人はいません
-      ul
-        - room.scores.each do |score|
+      .mt-4
+        .flex.items-center.justify-between
+          h2.font-bold.text-lg 入力者一覧
           - if score.persisted?
-            .flex
-              li = score.reviewer_name
-              = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score)
+            = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
+        - if room.scores.blank?
+          p.text-red-600 スコアを入力した人はいません
+        ul
+          - room.scores.each do |score|
+            - if score.persisted?
+              .flex.items-center.justify-between.mt-2
+                li.w-3/4 = score.reviewer_name
+                = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score),
+                class: 'bg-slate-950 block hover:bg-slate-700 py-0.5 px-1 rounded-lg text-center text-sm text-white w-16'
 
       h2 入力者（名前・ニックネーム）
       = form.text_field :reviewer_name

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -1,7 +1,7 @@
 .mx-10
   .md:w-1/3.mx-auto
     - if score.errors.present?
-      ul
+      ul.bg-red-100.border-red-400.flash-message.mt-2.text-red-700 role="alert"
         - score.errors.full_messages.each do |message|
           li = message
 

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -17,7 +17,7 @@
           - if score.persisted?
             = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
         - if room.scores.blank?
-          p.text-red-600 スコアを入力した人はいません
+          p.text-center.text-red-600.mt-2 スコアを入力した人はいません
         ul
           - room.scores.each do |score|
             - if score.persisted?

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -43,5 +43,4 @@
                 .flex.items-center.flex-col.text-sm
                   = form.label evaluation_item.to_sym, i + 1
                   = form.radio_button evaluation_item.to_sym, i + 1
-        .block
-          = form.submit 'スコアを保存する'
+        = form.submit 'スコアを保存する', class: 'btn-lg'

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -7,7 +7,7 @@
 
     = form_with model: [house_viewing, room, score], local: true, class: 'my-4' do |form|
       = form.fields_for :room do |room_fields|
-        = room_fields.text_field :name, value: room.name, class: 'block w-full'
+        = room_fields.text_field :name, value: room.name, class: 'text-field'
 
       p 分かりやすい名前に変更しましょう。
 
@@ -28,7 +28,7 @@
 
       .mt-6
         h2.font-bold.text-base 入力者（名前・ニックネーム）
-        = form.text_field :reviewer_name, class: 'block w-full'
+        = form.text_field :reviewer_name, class: 'text-field'
 
       .mt-6
         - evaluation_items.each do |evaluation_item|

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -39,8 +39,8 @@
               p = good_evaluation_name(evaluation_item)
               p = bad_evaluation_name(evaluation_item)
             div class="flex justify-between mx-auto px-1.5 w-4/5"
-              - 5.times do |i|
+              - Score::HIGHEST_SCORE.downto(Score::LOWEST_SCORE) do |i|
                 .flex.items-center.flex-col.text-sm
-                  = form.label evaluation_item.to_sym, i + 1
-                  = form.radio_button evaluation_item.to_sym, i + 1
+                  = form.label evaluation_item.to_sym, i
+                  = form.radio_button evaluation_item.to_sym, i
         = form.submit 'スコアを保存する', class: 'btn-lg'

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -35,7 +35,7 @@
           .mb-6
             h2.h2-title
               = evaluation_item
-            .flex.justify-between.mx-auto.text-sm.w-4/5
+            .flex.justify-between.mx-auto.mt-2.text-sm.w-4/5
               p = good_evaluation_name(evaluation_item)
               p = bad_evaluation_name(evaluation_item)
             div class="flex justify-between mx-auto px-1.5 w-4/5"

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -11,7 +11,7 @@
 
       p 分かりやすい名前に変更しましょう。
 
-      .mt-4
+      .mt-6
         .flex.items-center.justify-between
           h2.font-bold.text-base 入力者一覧
           - if score.persisted?
@@ -26,18 +26,22 @@
                 = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score),
                 class: 'bg-slate-950 block hover:bg-slate-700 py-0.5 px-1 rounded-lg text-center text-sm text-white w-16'
 
-      .mt-4
+      .mt-6
         h2.font-bold.text-base 入力者（名前・ニックネーム）
         = form.text_field :reviewer_name, class: 'block w-full'
 
-      - evaluation_items.each do |evaluation_item|
-        h2
-          = evaluation_item
-        .flex
-          p = good_evaluation_name(evaluation_item)
-          p = bad_evaluation_name(evaluation_item)
-        - 5.times do |i|
-          = form.label evaluation_item.to_sym, i + 1
-          = form.radio_button evaluation_item.to_sym, i + 1
-      .block
-        = form.submit 'スコアを保存する'
+      .mt-6
+        - evaluation_items.each do |evaluation_item|
+          .mb-6
+            h2.font-bold.text-base
+              = evaluation_item
+            .flex.justify-between.mx-auto.text-sm.w-4/5
+              p = good_evaluation_name(evaluation_item)
+              p = bad_evaluation_name(evaluation_item)
+            div class="flex justify-between mx-auto px-1.5 w-4/5"
+              - 5.times do |i|
+                .flex.items-center.flex-col.text-sm
+                  = form.label evaluation_item.to_sym, i + 1
+                  = form.radio_button evaluation_item.to_sym, i + 1
+        .block
+          = form.submit 'スコアを保存する'

--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -1,37 +1,39 @@
-- if score.errors.present?
-  ul
-    - score.errors.full_messages.each do |message|
-      li = message
+.mx-10
+  .md:w-1/3.mx-auto
+    - if score.errors.present?
+      ul
+        - score.errors.full_messages.each do |message|
+          li = message
 
-= form_with model: [house_viewing, room, score], local: true do |form|
-  = form.fields_for :room do |room_fields|
-    = room_fields.text_field :name, value: room.name
+    = form_with model: [house_viewing, room, score], local: true, class: 'my-4' do |form|
+      = form.fields_for :room do |room_fields|
+        = room_fields.text_field :name, value: room.name, class: 'block w-full'
 
-  p 分かりやすい名前に変更しましょう。
+      p 分かりやすい名前に変更しましょう。
 
-  .flex
-    h2 入力者一覧
-    - if score.persisted?
-      = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
-  - if room.scores.blank?
-    p スコアを入力した人はいません
-  ul
-    - room.scores.each do |score|
-      - if score.persisted?
+      .flex
+        h2 入力者一覧
+        - if score.persisted?
+          = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
+      - if room.scores.blank?
+        p スコアを入力した人はいません
+      ul
+        - room.scores.each do |score|
+          - if score.persisted?
+            .flex
+              li = score.reviewer_name
+              = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score)
+
+      h2 入力者（名前・ニックネーム）
+      = form.text_field :reviewer_name
+      - evaluation_items.each do |evaluation_item|
+        h2
+          = evaluation_item
         .flex
-          li = score.reviewer_name
-          = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score)
-
-  h2 入力者（名前・ニックネーム）
-  = form.text_field :reviewer_name
-  - evaluation_items.each do |evaluation_item|
-    h2
-      = evaluation_item
-    .flex
-      p = good_evaluation_name(evaluation_item)
-      p = bad_evaluation_name(evaluation_item)
-    - 5.times do |i|
-      = form.label evaluation_item.to_sym, i + 1
-      = form.radio_button evaluation_item.to_sym, i + 1
-  .block
-    = form.submit 'スコアを保存する'
+          p = good_evaluation_name(evaluation_item)
+          p = bad_evaluation_name(evaluation_item)
+        - 5.times do |i|
+          = form.label evaluation_item.to_sym, i + 1
+          = form.radio_button evaluation_item.to_sym, i + 1
+      .block
+        = form.submit 'スコアを保存する'

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,6 +1,6 @@
 header.header
   .header-container
-    svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+    svg.back-button.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
       = link_to house_viewing_rooms_path
         path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
     h1.h1-title = 'スコアを入力する'

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,5 +1,6 @@
-.flex
-  = link_to '<', house_viewing_rooms_path
-  h1
-    = 'スコアを入力する'
+header.border-b.border-black
+  .container.flex.justify-center.mx-auto.p-5
+    = link_to '<', house_viewing_rooms_path
+    h1.font-bold.text-2xl = 'スコアを入力する'
+
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,6 +1,8 @@
 header.header
   .header-container
-    = link_to '<', house_viewing_rooms_path
+    svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+      = link_to house_viewing_rooms_path
+        path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
     h1.h1-title = 'スコアを入力する'
 
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,8 +1,9 @@
 header.header
   .header-container
-    svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
-      = link_to house_viewing_rooms_path
-        path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
-    h1.h1-title = 'スコアを入力する'
+    .flex.items-center.md:w-1/3.mx-auto
+      svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+        = link_to house_viewing_rooms_path
+          path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
+      h1.h1-title = 'スコアを入力する'
 
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,6 +1,6 @@
-header.border-b.border-black
-  .container.flex.justify-center.mx-auto.p-5
+header.header
+  .header-container
     = link_to '<', house_viewing_rooms_path
-    h1.font-bold.text-2xl = 'スコアを入力する'
+    h1.h1-title = 'スコアを入力する'
 
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }

--- a/app/views/house_viewings/rooms/scores/new.html.slim
+++ b/app/views/house_viewings/rooms/scores/new.html.slim
@@ -1,9 +1,8 @@
 header.header
   .header-container
-    .flex.items-center.md:w-1/3.mx-auto
-      svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
-        = link_to house_viewing_rooms_path
-          path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
-      h1.h1-title = 'スコアを入力する'
+    svg.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+      = link_to house_viewing_rooms_path
+        path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
+    h1.h1-title = 'スコアを入力する'
 
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }


### PR DESCRIPTION
## 概要 
Tailwind CSSを用いて、お部屋のスコア入力ページにデザインを入れました。
スコア編集ページに関する部分には、このIssueではデザインを入れておりません。

## スクリーンショット
### お部屋のスコア入力ページ
<img width="600" alt="230713_スコア入力ページ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/a7b24797-1d50-480d-b079-d386c8ccd396">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230713_スコア入力ページ_スマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/af35ba9f-9380-4e1f-8548-419dd2449b33">

### エラーメッセージが表示された場合
<img width="600" alt="230713_スコア入力ページ_エラー" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/a07dfc08-f65c-4b43-b66e-960fb0676bb1">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230713_スコア入力ページ_エラー_スマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/4072ec0d-65c3-4fbd-97df-a01b5ed46e35">

## 関連Issue
- #109 

## 備考
以下の実装は別Issueにて実装します。
* 評価項目の日本語化

Close #109 
