### PR TITLE
お部屋のスコア入力/編集ページの日本語化対応を行う

### DIFF
--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -34,7 +34,7 @@
         - evaluation_items.each do |evaluation_item|
           .mb-6
             h2.h2-title
-              = evaluation_item
+              = Score.human_attribute_name(evaluation_item)
             .flex.justify-between.mx-auto.mt-2.text-sm.w-4/5
               p = good_evaluation_name(evaluation_item)
               p = bad_evaluation_name(evaluation_item)


### PR DESCRIPTION
## 概要 
お部屋のスコア入力ページ、スコア編集ページについて、以下の箇所を日本語化対応しました。
* 評価項目

## スクリーンショット
### 対応前
評価項目が英語になっている（赤枠にて強調）

<img width="600" alt="230713_スコア入力編集ページ_日本語化未対応" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/61fa3e68-b5c8-4df8-a90a-d81572980954">

### 対応後
評価項目が日本語化されている（赤枠にて強調）
<img width="600" alt="230713_スコア入力編集ページ_日本語化対応" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/bb7a2e5e-64da-4523-96eb-264d551c538d">

## 関連Issue
- #115 

Close #115 
