### PR TITLE
お部屋のスコア編集ページをデザインする

### DIFF
--- a/app/views/house_viewings/rooms/scores/_form.html.slim
+++ b/app/views/house_viewings/rooms/scores/_form.html.slim
@@ -15,7 +15,7 @@
         .flex.items-center.justify-between
           h2.h2-title 入力者一覧
           - if score.persisted?
-            = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id)
+            = link_to '新規入力', new_house_viewing_room_score_path(room_id: room.id), class: 'btn-sm'
         - if room.scores.blank?
           p.text-center.text-red-600.mt-2 スコアを入力した人はいません
         ul
@@ -23,8 +23,7 @@
             - if score.persisted?
               .flex.items-center.justify-between.mt-2
                 li.w-3/4 = score.reviewer_name
-                = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score),
-                class: 'btn-sm'
+                = link_to '編集', edit_house_viewing_room_score_path(house_viewing, room, score), class: 'btn-sm'
 
       .mt-6
         h2.h2-title 入力者（名前・ニックネーム）

--- a/app/views/house_viewings/rooms/scores/edit.html.slim
+++ b/app/views/house_viewings/rooms/scores/edit.html.slim
@@ -1,4 +1,8 @@
-.flex
-  = link_to '<', house_viewing_rooms_path
-  h1 スコアを編集する
+header.header
+  .header-container
+    svg.back-button.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+      = link_to house_viewing_rooms_path
+        path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
+    h1.h1-title = 'スコアを編集する'
+
 = render partial: 'form', locals: { house_viewing: @house_viewing, room: @room, score: @score }


### PR DESCRIPTION
## 概要 
Tailwind CSSを用いて、お部屋のスコア編集ページにデザインを入れました。
デザインを入れた箇所は以下の通りです。
* タイトル
* 新規入力ボタン

## スクリーンショット
### お部屋のスコア編集ページ
デザインの適用箇所を赤枠で強調しています。
<img width="600" alt="230713_スコア編集ページ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/6790d5a4-3757-416c-bd7e-ace4d7a2b01c">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230713_スコア編集ページスマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/0297fe05-7f11-46dc-af6e-27768694092f">

## 関連Issue
- #117 

Close #117 