### PR TITLE
お部屋のスコア結果ページをデザインする

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -42,4 +42,8 @@
   .table-border {
     @apply border border-black;
   }
+
+  .list-row {
+    @apply border border-b-0 border-black cursor-pointer last:border-b;
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -46,4 +46,8 @@
   .list-row {
     @apply border border-b-0 border-black cursor-pointer last:border-b;
   }
+
+  .number-circle {
+    @apply border border-black border-solid flex h-6 items-center justify-center my-auto rounded-full w-6
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -38,4 +38,8 @@
   .text-field {
     @apply block w-full rounded-lg;
   }
+
+  .table-border {
+    @apply border border-black;
+  }
 }

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -6,7 +6,7 @@ header.header
   .md:w-1/3.mx-auto
     ul.mb-2
       - @rooms.each do |room|
-        li.border.border-b-0.border-black.cursor-pointer.px-2.py-1.last:border-b
+        li.list-row.px-2.py-1
           = link_to new_house_viewing_room_score_path(room_id: room.id) do
             .flex.justify-between.items-center
               div

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -31,9 +31,12 @@ header.header
 
     h2.h1-title お部屋ごとのスコア
     p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
-    table
-      tbody
-        - @rooms.each do |room|
-          tr
-            td = link_to room.name, house_viewing_room_scores_path(room_id: room.id)
-            td = "#{room.average_total_score} 点"
+    ul.my-2
+      - @rooms.each do |room|
+        li.border.border-b-0.border-black.cursor-pointer.px-3.py-2.first:rounded-t-lg.last:border-b.last:rounded-b-lg
+          = link_to house_viewing_room_scores_path(room_id: room.id) do
+            .flex.justify-between.items-center
+              div
+                = room.name
+              div
+                = "#{room.average_total_score} 点"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -7,7 +7,7 @@ header.header
 
 .mx-10.my-6
   .md:w-1/3.mx-auto
-    h2.h1-title 総合スコア
+    h2.font-bold.text-xl 総合スコア
     p 上位2部屋の平均点を表示します。
     ul.mt-2
       - @top_two_rooms.each.with_index(1) do |room, i|
@@ -33,7 +33,7 @@ header.header
             - @top_two_rooms.each do |room|
               td.table-border = "#{room.average_score(evaluation_item)} 点"
 
-    h2.h1-title お部屋ごとのスコア
+    h2.font-bold.text-xl お部屋ごとのスコア
     p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     ul.my-2
       - @rooms.each do |room|

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -5,36 +5,38 @@ header.header
         path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
     h1.h1-title お部屋のスコア
 
-h2 総合スコア
-p 上位2件のお部屋を表示します。
-table
-  tbody
-    - @top_two_rooms.each do |room|
-      tr
-        td = room.name
-        td = "#{room.average_total_score} 点"
-
-h3 上位2件のスコアを比較
-table
-  tbody
-    tr
-      th
-      - @top_two_rooms.each do |room|
-        th = room.name
-    - Score::EVALUATION_ITEMS.each do |evaluation_item|
-      tr
-        td = Score.human_attribute_name(evaluation_item)
+.mx-10.my-6
+  .md:w-1/3.mx-auto
+    h2.h1-title 総合スコア
+    p 上位2部屋の平均点を表示します。
+    table
+      tbody
         - @top_two_rooms.each do |room|
-          td = "#{room.average_score(evaluation_item)} 点"
+          tr
+            td = room.name
+            td = "#{room.average_total_score} 点"
 
-h2 お部屋ごとのスコア
-p
-  | 合計スコアが高い順に表示します。
-  br
-  | お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
-table
-  tbody
-    - @rooms.each do |room|
-      tr
-        td = link_to room.name, house_viewing_room_scores_path(room_id: room.id)
-        td = "#{room.average_total_score} 点"
+    h3 上位2件のスコアを比較
+    table
+      tbody
+        tr
+          th
+          - @top_two_rooms.each do |room|
+            th = room.name
+        - Score::EVALUATION_ITEMS.each do |evaluation_item|
+          tr
+            td = Score.human_attribute_name(evaluation_item)
+            - @top_two_rooms.each do |room|
+              td = "#{room.average_score(evaluation_item)} 点"
+
+    h2 お部屋ごとのスコア
+    p
+      | 合計スコアが高い順に表示します。
+      br
+      | お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
+    table
+      tbody
+        - @rooms.each do |room|
+          tr
+            td = link_to room.name, house_viewing_room_scores_path(room_id: room.id)
+            td = "#{room.average_total_score} 点"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -9,12 +9,16 @@ header.header
   .md:w-1/3.mx-auto
     h2.h1-title 総合スコア
     p 上位2部屋の平均点を表示します。
-    table
-      tbody
-        - @top_two_rooms.each do |room|
-          tr
-            td = room.name
-            td = "#{room.average_total_score} 点"
+    ul.mt-2
+      - @top_two_rooms.each.with_index(1) do |room, i|
+        li.mb-2.text-lg.first:font-bold
+          .flex.items-center.justify-between
+            .number-circle.w-1/10
+              = i
+            .grow.ml-2.w-1/2
+              = room.name
+            div
+              = "#{room.average_total_score} 点"
 
     h3.mt-4.h2-title 上位2件のスコアを比較
     table.mb-6.mt-2.p-2.w-full

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -26,12 +26,12 @@ header.header
         tr
           th.table-border
           - @top_two_rooms.each do |room|
-            th.table-border = room.name
+            th.table-border.w-1/3 = room.name
         - Score::EVALUATION_ITEMS.each do |evaluation_item|
-          tr.text-center
-            td.table-border = Score.human_attribute_name(evaluation_item)
+          tr.text-center.w-2/3
+            td.table-border.w-1/3 = Score.human_attribute_name(evaluation_item)
             - @top_two_rooms.each do |room|
-              td.table-border = "#{room.average_score(evaluation_item)} 点"
+              td.table-border.w-1/3 = "#{room.average_score(evaluation_item)} 点"
 
     h2.font-bold.text-xl お部屋ごとのスコア
     p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -40,7 +40,7 @@ header.header
         li.list-row.px-3.py-2.first:rounded-t-lg.last:rounded-b-lg
           = link_to house_viewing_room_scores_path(room_id: room.id) do
             .flex.justify-between.items-center
-              div
+              .w-4/5
                 = room.name
               div
                 = "#{room.average_total_score} 点"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -1,6 +1,9 @@
-.flex
-  = link_to '<', house_viewing_rooms_path
-  h1 お部屋のスコア
+header.header
+  .header-container
+    svg.back-button.w-5.h-5 aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
+      = link_to house_viewing_rooms_path
+        path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 1 1.3 6.326a.91.91 0 0 0 0 1.348L7 13"]
+    h1.h1-title お部屋のスコア
 
 h2 総合スコア
 p 上位2件のお部屋を表示します。

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -33,7 +33,7 @@ header.header
     p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     ul.my-2
       - @rooms.each do |room|
-        li.border.border-b-0.border-black.cursor-pointer.px-3.py-2.first:rounded-t-lg.last:border-b.last:rounded-b-lg
+        li.list-row.px-3.py-2.first:rounded-t-lg.last:rounded-b-lg
           = link_to house_viewing_room_scores_path(room_id: room.id) do
             .flex.justify-between.items-center
               div

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -16,18 +16,18 @@ header.header
             td = room.name
             td = "#{room.average_total_score} 点"
 
-    h3 上位2件のスコアを比較
-    table
+    h3.mt-4.h2-title 上位2件のスコアを比較
+    table.mb-4.mt-2.p-2.w-full
       tbody
         tr
-          th
+          th.table-border
           - @top_two_rooms.each do |room|
-            th = room.name
+            th.table-border = room.name
         - Score::EVALUATION_ITEMS.each do |evaluation_item|
-          tr
-            td = Score.human_attribute_name(evaluation_item)
+          tr.text-center
+            td.table-border = Score.human_attribute_name(evaluation_item)
             - @top_two_rooms.each do |room|
-              td = "#{room.average_score(evaluation_item)} 点"
+              td.table-border = "#{room.average_score(evaluation_item)} 点"
 
     h2 お部屋ごとのスコア
     p

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -17,7 +17,7 @@ header.header
             td = "#{room.average_total_score} 点"
 
     h3.mt-4.h2-title 上位2件のスコアを比較
-    table.mb-4.mt-2.p-2.w-full
+    table.mb-6.mt-2.p-2.w-full
       tbody
         tr
           th.table-border
@@ -29,11 +29,8 @@ header.header
             - @top_two_rooms.each do |room|
               td.table-border = "#{room.average_score(evaluation_item)} 点"
 
-    h2 お部屋ごとのスコア
-    p
-      | 合計スコアが高い順に表示します。
-      br
-      | お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
+    h2.h1-title お部屋ごとのスコア
+    p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     table
       tbody
         - @rooms.each do |room|


### PR DESCRIPTION
## 概要 
Tailwind CSSを用いて、お部屋のスコア結果ページにデザインを入れました。
デザインを入れた箇所は以下の通りです。
* 総合スコア
* 総合スコア上位2件について、評価項目ごとの比較
* お部屋ごとのスコア

また、お部屋ごとのスコアについて、スコア詳細ページへのリンクの範囲を広げました。

## スクリーンショット
### お部屋のスコア結果ページ
<img width="600" alt="230714_スコア結果ページ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/a1f709a9-8d2b-40fb-b0e2-81ec755ac05c">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230714_スコア結果ページ_スマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/f06e7595-a0a5-4d92-806e-7b2d8eab8a4c">

## 関連Issue
- #118 

Close #118 