### PR TITLE
アプリ説明ページをデザインする

### DIFF
--- a/app/views/description/house_viewings/show.html.slim
+++ b/app/views/description/house_viewings/show.html.slim
@@ -1,2 +1,4 @@
-= render partial: 'shared/summary'
-= link_to 'スコアを入力する', house_viewing_rooms_path(@house_viewing)
+.flex.items-center.h-screen.mx-10
+  .md:w-1/3.mx-auto
+    = render partial: 'shared/summary'
+    = link_to 'スコアを入力する', house_viewing_rooms_path(@house_viewing), class: 'btn-md w-3/4'


### PR DESCRIPTION
## 概要 
Tailwind CSSを用いて、アプリ説明ページ（招待URLにアクセスすると表示するページ）にデザインを入れました。
デザインを入れた箇所は以下の通りです。
* タイトル・概要
* 使い方
* 「スコアを入力する」ボタン

## スクリーンショット
### TOPページ
<img width="600" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/fae9dde8-dab7-4fc2-b970-28c351a9ca90">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="image" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/0a44ea4e-29ba-459a-b333-a05994499177">

## 関連Issue
- #139 

Close #139 