### PR TITLE
内見一覧ページ・スコア入力ページに関する説明を補足する

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -19,4 +19,8 @@ class Room < ApplicationRecord
 
     (scores.sum(attribute_name).to_f / scores.length).round(1)
   end
+
+  def reviewer_names
+    scores.pluck(:reviewer_name)
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -11,10 +11,7 @@ class Room < ApplicationRecord
   end
 
   def average_total_score
-    sum_total_scores = Score::EVALUATION_ITEMS.sum { |attribute_name| scores.sum(attribute_name) }.to_f
-    return 0 if scores.blank?
-
-    (sum_total_scores / scores.length).round
+    Score::EVALUATION_ITEMS.sum { |attribute_name| average_score(attribute_name) }
   end
 
   def average_score(attribute_name)

--- a/app/views/house_viewings/rooms/index.html.slim
+++ b/app/views/house_viewings/rooms/index.html.slim
@@ -12,8 +12,8 @@ header.header
               div
                 div
                   = room.name
-                div
-                  = "スコア入力数: #{room.scores.length}"
+                .text-sm
+                  = "入力者: #{room.reviewer_names.join('、')}"
               div
                 svg.w-4.h-4.mx-auto xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 8 14"
                   path[stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -21,7 +21,8 @@ header.header
             div
               = "#{room.average_total_score} 点"
 
-    h3.mt-4.h2-title 上位2件のスコアを比較
+    h3.mt-4.h2-title 上位2部屋のスコアを比較
+    p.text-sm 総合スコア上位2部屋について、入力者全体の平均点を評価項目ごとに比較できます。
     table.mb-6.mt-2.p-2.w-full
       tbody
         tr

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -8,7 +8,8 @@ header.header
 .mx-10.my-6
   .md:w-1/3.mx-auto
     h2.font-bold.text-xl 総合スコア
-    p 上位2部屋の平均点を表示します。
+    p.text-sm 総合スコア上位2部屋を表示します。
+    p.text-sm 評価項目ごとに入力者全体の平均点を算出し、合計したものが総合スコアです。
     ul.mt-2
       - @top_two_rooms.each.with_index(1) do |room, i|
         li.mb-2.text-lg.first:font-bold

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -23,18 +23,22 @@ header.header
 
     h3.mt-4.h2-title 上位2部屋のスコアを比較
     p.text-sm 総合スコア上位2部屋について、入力者全体の平均点を評価項目ごとに比較できます。
+    p.text-sm 各評価項目は最低が1点、最高が5点です。
     table.mb-6.mt-2.p-2.w-full
       tbody
         tr
-          th.table-border
+          th.table-border.w-2/5
           - @top_two_rooms.each do |room|
-            th.table-border.w-1/3 = room.name
+            th.table-border.w-3/10 = room.name
         - Score::EVALUATION_ITEMS.each do |evaluation_item|
-          tr.text-center.w-2/3
-            td.table-border.w-1/3 = Score.human_attribute_name(evaluation_item)
+          tr.text-center
+            td.table-border.w-2/5 = Score.human_attribute_name(evaluation_item)
             - @top_two_rooms.each do |room|
-              td.table-border.w-1/3 = "#{room.average_score(evaluation_item)} 点"
-
+              td.table-border.w-3/10 = "#{room.average_score(evaluation_item)} 点"
+        tr.text-center
+          td.font-bold.table-border.w-2/5 総合スコア
+          - @top_two_rooms.each do |room|
+            td.font-bold.table-border.w-3/10 = "#{room.average_total_score} 点"
     h2.font-bold.text-xl お部屋ごとのスコア
     p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     ul.my-2

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -40,13 +40,13 @@ header.header
           - @top_two_rooms.each do |room|
             td.font-bold.table-border.w-3/10 = "#{room.average_total_score} 点"
     h2.font-bold.text-xl お部屋ごとのスコア
-    p お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
+    p.text-sm お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     ul.my-2
       - @rooms.each do |room|
         li.list-row.px-3.py-2.first:rounded-t-lg.last:rounded-b-lg
           = link_to house_viewing_room_scores_path(room_id: room.id) do
             .flex.justify-between.items-center
-              .w-4/5
+              .w-2/3
                 = room.name
               div
                 = "#{room.average_total_score} 点"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -8,7 +8,7 @@ header.header
 .mx-10.my-6
   .md:w-1/3.mx-auto
     h2.font-bold.text-xl 総合スコア
-    p.text-sm 総合スコア上位2部屋を表示します。
+    p.text-sm 上位2部屋を表示します。
     p.text-sm 評価項目ごとに入力者全体の平均点を算出し、合計したものが総合スコアです。
     ul.mt-2
       - @top_two_rooms.each.with_index(1) do |room, i|
@@ -16,15 +16,15 @@ header.header
           .flex.items-center.justify-between
             .number-circle.w-1/10
               = i
-            .grow.ml-2.w-1/2
+            .grow.mx-2.w-1/2
               = room.name
             div
               = "#{room.average_total_score} 点"
-
+              .text-right.text-sm &#47; 40点
     h3.mt-4.h2-title 上位2部屋のスコアを比較
     p.text-sm 総合スコア上位2部屋について、入力者全体の平均点を評価項目ごとに比較できます。
     p.text-sm 各評価項目は最低が1点、最高が5点です。
-    table.mb-6.mt-2.p-2.w-full
+    table.mb-8.mt-2.p-2.w-full
       tbody
         tr
           th.table-border.w-2/5

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -24,21 +24,21 @@ header.header
     h3.mt-4.h2-title 上位2部屋のスコアを比較
     p.text-sm 総合スコア上位2部屋について、入力者全体の平均点を評価項目ごとに比較できます。
     p.text-sm 各評価項目は最低が1点、最高が5点です。
-    table.mb-8.mt-2.p-2.w-full
+    table.break-words.mb-8.mt-2.p-2.table-fixed.w-full
       tbody
         tr
           th.table-border.w-2/5
           - @top_two_rooms.each do |room|
-            th.table-border.w-3/10 = room.name
+            th.table-border = room.name
         - Score::EVALUATION_ITEMS.each do |evaluation_item|
           tr.text-center
             td.table-border.w-2/5 = Score.human_attribute_name(evaluation_item)
             - @top_two_rooms.each do |room|
-              td.table-border.w-3/10 = room.average_score(evaluation_item)
+              td.table-border = room.average_score(evaluation_item)
         tr.text-center
           td.font-bold.table-border.w-2/5 総合スコア
           - @top_two_rooms.each do |room|
-            td.font-bold.table-border.w-3/10 = "#{room.average_total_score} 点"
+            td.font-bold.table-border = "#{room.average_total_score} 点"
     h2.font-bold.text-xl お部屋ごとのスコア
     p.text-sm お部屋の名前をタップ・クリックするとスコアの詳細ページに移動します。
     ul.my-2

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -13,14 +13,14 @@ header.header
     ul.mt-2
       - @top_two_rooms.each.with_index(1) do |room, i|
         li.mb-2.text-lg.first:font-bold
-          .flex.items-center.justify-between
-            .number-circle.w-1/10
+          .flex
+            .number-circle.w-1/10.mr-2
               = i
-            .grow.mx-2.w-1/2
-              = room.name
             div
-              = "#{room.average_total_score} 点"
-              .text-right.text-sm &#47; 40点
+              = room.name
+          .text-right
+            = "#{room.average_total_score}点"
+            span.text-sm &#47;40点
     h3.mt-4.h2-title 上位2部屋のスコアを比較
     p.text-sm 総合スコア上位2部屋について、入力者全体の平均点を評価項目ごとに比較できます。
     p.text-sm 各評価項目は最低が1点、最高が5点です。

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -16,7 +16,7 @@ header.header
           .flex
             .number-circle.w-1/10.mr-2
               = i
-            div
+            .grow.w-1/2
               = room.name
           .text-right
             = "#{room.average_total_score}点"

--- a/app/views/house_viewings/scores/index.html.slim
+++ b/app/views/house_viewings/scores/index.html.slim
@@ -34,7 +34,7 @@ header.header
           tr.text-center
             td.table-border.w-2/5 = Score.human_attribute_name(evaluation_item)
             - @top_two_rooms.each do |room|
-              td.table-border.w-3/10 = "#{room.average_score(evaluation_item)} 点"
+              td.table-border.w-3/10 = room.average_score(evaluation_item)
         tr.text-center
           td.font-bold.table-border.w-2/5 総合スコア
           - @top_two_rooms.each do |room|


### PR DESCRIPTION
## 概要 
内見一覧ページ・スコア入力ページに関するについて、以下の形で説明の補足、レイアウトの調整を行いました。
### 内見一覧ページ
* 「スコア入力数」を「スコア入力者」に変更

### スコア入力ページ
* 総合スコアに関する説明文を修正
* 総合スコアに満点の場合の点数を表示
*  総合スコアの算出方法を変更
* 「上位2部屋のスコアを比較」に関する説明文を修正
* 「上位2部屋のスコアを比較」に総合スコアを追加

## スクリーンショット
### 内見一覧ページ
<img width="600" alt="230726_内見一覧ページ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/8b87c6c8-7092-4262-ad7b-286537f88207">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230726_内見一覧ページ_スマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/48be8085-6886-449c-a7d7-f895a782cf0d">

### スコア入力ページ
<img width="600" alt="230726_スコア結果ページ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/14566f75-a7c3-4d98-9382-4efe10da6ab0">

デベロッパツールで「iPhone SE」の画面（375 × 667）を想定して表示した場合
<img width="200" alt="230726_スコア結果ページ_スマホ" src="https://github.com/uchihiro04/house-viewing-score-log/assets/77523896/c509f6bf-d715-41ab-bdc9-e94268646fdc">

## 関連Issue
- #150 

Close #150 