### PR TITLE
検索画面のレイアウトを修正する

### DIFF
--- a/app/views/dashboard/rooms/index.html.slim
+++ b/app/views/dashboard/rooms/index.html.slim
@@ -8,16 +8,14 @@ header.header
 .mx-10.my-6
   .md:w-1/2.mx-auto
     = form_with url: dashboard_rooms_path, method: :get, local: true do |form|
-      .flex.items-center
+      .flex.items-center.justify-center
         .mr-4 総合スコア
         = form.number_field :min_score, in: 0..40
         .mx-4 〜
         = form.number_field :max_score, in: 0..40
+        = form.submit '絞り込む', class: 'btn-sm ml-4'
 
-      div
-        = form.submit '絞り込む'
-
-    table
+    table.mx-auto.mt-4.text-center
       thead
         tr
           th = Room.human_attribute_name(:name)


### PR DESCRIPTION
## 概要 
検索画面について、以下の修正を行いました。
* 検索フォームと「絞り込む」ボタンを横並びに修正
* 検索フォームを中央揃えに修正
* 検索結果を中央揃えに修正

## スクリーンショット


## 関連Issue
close #158 